### PR TITLE
Fix: songs not playing fully/skipping to next before the end

### DIFF
--- a/socketwrapper/socketwrapper.cpp
+++ b/socketwrapper/socketwrapper.cpp
@@ -79,6 +79,11 @@
 // Version 1.11
 // Fix to stop socketwrapper not shutting down properly when input from stdin and output pipe is closed.
 //
+// ++++++
+// Version 1.12
+// Fix to limit the watchdog on remote stream read. The watchdog will no longer stop the worker thread
+// when waiting for LMS to read data.
+//
 
 #include <process.h>
 #include "stdafx.h"
@@ -105,6 +110,7 @@ typedef struct
 	HANDLE hInput;			// input handle for process/thread
 	HANDLE hOutput;			// output handle for process/thread
 	DWORD WatchDog;			// watchdog for worker threads
+	BOOL bIsWriting;        // true when stage thread is writing back to LMS server
 	DWORD nBlocks;			// number of "blocks" read
 	DWORD nBytes;			// number of bytes read
 } Stage;
@@ -212,6 +218,7 @@ unsigned __stdcall MoveDataThreadProc(void *pv)
 		}
 
 		// wait for some data from input
+		pS->bIsWriting = false;
 		if( !ReadFile(pS->hInput, pS->pBuff, BUFFER_SIZE, &bytesread, NULL) ) {
 			stderrMsg ( "MoveDataThreadProc for step %i failed reading with error %i.\n", pS->i, GetLastError() );
 			break;
@@ -236,6 +243,7 @@ unsigned __stdcall MoveDataThreadProc(void *pv)
 		}
 
 		// pass data to output
+		pS->bIsWriting = true;
 		if (!pS->fOutputIsSocket){
 			if( !WriteFile(pS->hOutput, pS->pBuff, bytesread, &byteswritten, NULL) ) {
 				stderrMsg ( "MoveDataThreadProc for step %i failed WriteFile with error %i.\n", pS->i, GetLastError() );
@@ -260,7 +268,7 @@ unsigned __stdcall MoveDataThreadProc(void *pv)
 		if (nNummsgs > 1 && !bDebugVerbose) fShowDebug = false;
 	}
 
-
+	pS->bIsWriting = false;
 	debugMsg ( "MoveDataThreadProc for step %i ending.\n", pS->i );
 	if (!pS->fOutputIsSocket) {
 		if (!FlushFileBuffers(pS->hOutput)) {
@@ -596,7 +604,7 @@ DWORD main(int argc, char **argv)
 			fDie = true;
 		}
 		for( int i=0; i<numSteps; ++i ){
-			if( info[i].fIsWorkerThread ){
+			if( info[i].fIsWorkerThread && !info[i].bIsWriting){
 				if( 0==info[i].WatchDog ) {
 					stderrMsg( "Watchdog expired - Thread for step %i stalled.\n", i );
 					if (bWatchdogEnabled)	fDie = true;


### PR DESCRIPTION
This Fix is to limit the watchdog's actions on remote stream read operations only. The watchdog will no longer stop the worker thread when waiting for LMS to read data.  

On windows, when streaming remote sources (e.g. spotty), playback buffer (stream controller, player, etc) would fill quickly and not request more data for a duration that caused the socketwrapper's WDT mechanism to trigger. This is a simple fix that introduces a new boolean indicator inside of the stage structure:
```	
BOOL bIsWriting;
```

Stage threads update the flag during both the read phase (bIsWriting=false) and the writing phase (bIsWriting=true). This allows the main socketwrapper's thread to figure out if a given stage thread is reading from a remote socket, where the wdt applies, or if it is waiting for the stage thread to write back to LMS., where the wdt should not apply. (_**&& !info[i].bIsWriting**_ below)

```
if (info[i].fIsWorkerThread) {
	if (0 == info[i].WatchDog && !info[i].bIsWriting) {
		stderrMsg("Watchdog expired - Thread for step %i stalled.\n", i);
		if (bWatchdogEnabled)	fDie = true;
	}
	info[i].WatchDog = 0;
}
```
